### PR TITLE
Fixed pfCluster and superCluster mapping for caloparticles

### DIFF
--- a/Dumpers/plugins/RecoSimDumper.h
+++ b/Dumpers/plugins/RecoSimDumper.h
@@ -188,7 +188,7 @@ class RecoSimDumper : public edm::EDAnalyzer
       std::vector<std::vector<int> > pfRecHit_ieta;
       std::vector<std::vector<int> > pfRecHit_iphi;
       std::vector<std::vector<int> > pfRecHit_iz;
-      std::vector<std::vector<float> > pfClusterHit_energy;
+      std::vector<std::vector< std::map<int, float> >> pfClusterHit_energy; // caloparticle, simhit, cluster:energy
       std::vector<std::vector<float> > pfClusterHit_eta;
       std::vector<std::vector<float> > pfClusterHit_phi;
       std::vector<std::vector<int> > pfClusterHit_ieta;
@@ -203,7 +203,7 @@ class RecoSimDumper : public edm::EDAnalyzer
       std::vector<float> pfCluster_energy;
       std::vector<float> pfCluster_eta;
       std::vector<float> pfCluster_phi;
-      std::vector<std::vector<float> > superClusterHit_energy;
+      std::vector<std::vector< std::map<int, float> >> superClusterHit_energy;
       std::vector<std::vector<float> > superClusterHit_eta;
       std::vector<std::vector<float> > superClusterHit_phi;  
       std::vector<std::vector<int> > superClusterHit_ieta;
@@ -217,15 +217,7 @@ class RecoSimDumper : public edm::EDAnalyzer
       std::vector<std::vector<int> > superClusterHit_noCaloPart_iz;  
       std::vector<float> superCluster_energy;
       std::vector<float> superCluster_eta;
-      std::vector<float> superCluster_phi;
-      std::vector<std::map<int,std::vector<int> >> map_simHit_pfCluster; 
-      std::vector<std::map<int,std::vector<int> >> map_recHit_pfCluster;
-      std::vector<std::map<int,std::vector<int> >> map_pfRecHit_pfCluster;
-      std::vector<std::map<int,std::vector<int> >> map_pfClusterHit_pfCluster;   
-      std::vector<std::map<int,std::vector<int> >> map_simHit_superCluster; 
-      std::vector<std::map<int,std::vector<int> >> map_recHit_superCluster;
-      std::vector<std::map<int,std::vector<int> >> map_pfRecHit_superCluster;
-      std::vector<std::map<int,std::vector<int> >> map_superClusterHit_superCluster;    
+      std::vector<float> superCluster_phi;    
 };
 
 #endif

--- a/Dumpers/src/classes.h
+++ b/Dumpers/src/classes.h
@@ -7,7 +7,8 @@ namespace
 
   std::vector<std::vector<bool> > dummy0;
   std::vector<std::map<int,int> > dummy1;
-  std::vector<std::map<int,vector<int> > > dummy2;  
+  std::vector<std::map<int,float> > dummy2;
+  std::vector<std::vector< std::map<int, float> >> dummy3;  
 
  };
 }

--- a/Dumpers/src/classes_def.xml
+++ b/Dumpers/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
   <class name="std::vector<std::vector<bool> >"/>
   <class name="std::vector<std::map<int,int> >"/>
-  <class name="std::vector<std::map<int,vector<int> > >"/>
+  <class name="std::vector<std::map<int,float> >"/>
+  <class name="std::vector<std::vector< std::map<int, float> >>"/>
 </lcgdict>


### PR DESCRIPTION
For each caloparticle, for each detid, we save now a map of pfClusterindex:energy.

In this way the overlapping can be studied completely.

Fixed also rechit default energy (-1) in case of missing rechit